### PR TITLE
Optionally set `/wiki` as safe directory (default off)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Any Github changes require admin approval
+/** @GTNewHorizons/admin
+

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ In this example, the `wiki` folder will be synced with the wiki repo everytime a
 | `username` | Y | The repo owner's name. Used for pulling and pushing |
 | `access_token` | Y | An access token to use when pushing to the Wiki repo, can be set using `${{ secrets.GITHUB_TOKEN }}` |
 | `wiki_folder` | N | The folder to sync to the Wiki. <br/> <i>Default: `wiki`</i> |
+| `ignore_safe_warnings` | N | Fixes `fatal: detected dubious ownership in repository at '/wiki'` <br/> <i>Default: `false`</i> |
 | `commit_username` | Y | The username to use when pushing to the wiki repo |
 | `commit_email` | Y | The email address to use when pushing to the wiki repo. Our example uses the [annonymous email](https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/setting-your-commit-email-address) from GitHub |
 | `commit_message` | N | The commit message to use when pushing to the wiki repo <br/><i>Default: `action: wiki sync` |

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
         description: 'The folder you want to sync the repo with'
         required: false
         default: 'wiki'
+    ignore_safe_warnings:
+        description: 'Fixes `fatal: detected dubious ownership in repository at /wiki`'
+        required: false
+        default: 'false'
     commit_message:
         description: 'A custom commit message to be used'
         required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,6 +20,11 @@ if [ ! -d "/github/workspace/${INPUT_WIKI_FOLDER}" ]; then
 fi
 cp -a ${INPUT_WIKI_FOLDER}/. /wiki
 
+if [ "${INPUT_IGNORE_SAFE_WARNINGS}" = "true" ]; then
+    chown -R $USER:$USER /wiki
+    git config --global --add safe.directory /wiki
+fi
+
 echo "Git Config..."
 echo "-> User: ${INPUT_COMMIT_USERNAME}"
 echo "-> Email: ${INPUT_COMMIT_EMAIL}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,6 @@ fi
 cp -a ${INPUT_WIKI_FOLDER}/. /wiki
 
 if [ "${INPUT_IGNORE_SAFE_WARNINGS}" = "true" ]; then
-    chown -R $USER:$USER /wiki
     git config --global --add safe.directory /wiki
 fi
 


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/ServerUtilities/actions/runs/7378671398/job/20074070829#step:4:18.
To be used in https://github.com/GTNewHorizons/ServerUtilities/pull/24.
Based on https://github.com/JoeIzzard/ghaction-wiki-sync/pull/3.